### PR TITLE
Make the `boto3` package optional

### DIFF
--- a/bioformats/formatreader.py
+++ b/bioformats/formatreader.py
@@ -50,7 +50,11 @@ import javabridge as jutil
 import bioformats
 from . import metadatatools as metadatatools
 import javabridge as javabridge
-import boto3
+try:
+    import boto3
+except ImportError:
+    boto3 = None
+    pass
 
 OMERO_READER_IMPORTED = False
 try:
@@ -682,6 +686,8 @@ class ImageReader(object):
         self.using_temp_file = True
 
         if scheme == 's3':
+            if boto3 is None:
+                raise ImportError("Please install 'boto3'")
             client = boto3.client('s3')
             bucket_name, key = re.compile('s3://([\w\d\-\.]+)/(.*)').search(url).groups()
             url = client.generate_presigned_url(

--- a/setup.py
+++ b/setup.py
@@ -76,10 +76,12 @@ setuptools.setup(
     extras_require={
         "test": [
             "pytest>=3.3.2,<4"
-        ]
+        ],
+        "aws": [
+            "boto3>=1.14.23",
+        ],
     },
     install_requires=[
-        "boto3>=1.14.23",
         "future>=0.18.2",
         "javabridge"
     ],


### PR DESCRIPTION
The `boto3` package appears to only be used when accessing files from AWS S3. Make this package optional, installed in a new `aws` group. Raise a warning when attempting to load a file from S3 if `boto3` is not installed.